### PR TITLE
Add `domainDefined` dictionary to model

### DIFF
--- a/api/helpers/get-domains.js
+++ b/api/helpers/get-domains.js
@@ -28,15 +28,21 @@ module.exports = {
 
     fn: async function(inputs, exits) {
         let result = {};
-        for (let property in inputs.model.attributes) {
-            if (sails.helpers.isAssociation(inputs.model, property)) {
-                result[property] = await sails.models[inputs.model.attributes[property].model].find().sort("name ASC");
-            }
-            else if (inputs.model.attributes[property].validations &&
-                inputs.model.attributes[property].validations.isIn) {
-                result[property] = [];
-                for (let i = 0; i < inputs.model.attributes[property].validations.isIn.length; i++) {
-                    result[property].push({ name: inputs.model.attributes[property].validations.isIn[i] });
+        if (inputs.model.domainDefined) {
+            for (let property in inputs.model.domainDefined) {
+                if (!inputs.model.domainDefined[property]) continue;
+                if (sails.helpers.isAssociation(inputs.model, property)) {
+                    result[property] = await sails.models[inputs.model.attributes[property].model].find().sort("name ASC");
+                }
+                else if (inputs.model.attributes[property].validations &&
+                    inputs.model.attributes[property].validations.isIn) {
+                    result[property] = [];
+                    for (let i = 0; i < inputs.model.attributes[property].validations.isIn.length; i++) {
+                        result[property].push({ name: inputs.model.attributes[property].validations.isIn[i] });
+                    }
+                }
+                else {
+                    sails.log.warn(`Unable to find domain values for ${inputs.model.identity}.${property}`);
                 }
             }
         }

--- a/api/models/Student.js
+++ b/api/models/Student.js
@@ -20,6 +20,17 @@ module.exports = {
         forceUpdate: { type: "boolean", defaultsTo: true }
     },
     
+    /** Indicates which model attributes have defined domains.
+     */
+    domainDefined: {
+        academicRank: true,
+        majorOne: true,
+        majorTwo: true,
+        residentialStatus: true,
+        fallSport: true,
+        springSport: true
+    },
+
     /**
      * Populates the database with sample data for use in development environments.
      * @modifies Database contents.

--- a/api/models/Visit.js
+++ b/api/models/Visit.js
@@ -18,6 +18,12 @@ module.exports = {
         comment: { type: "string", allowNull: true },
         isLengthEstimated: { type: "boolean", allowNull: false, defaultsTo: false },
     },
+    
+    /** Indicates which model attributes have defined domains.
+     */
+    domainDefined: {
+        purposeAchieved: true
+    },
 
     afterPopulateOne: function(visit) {
         let checkIn = new Date(visit.checkInTime);

--- a/test/models/_helpers.js
+++ b/test/models/_helpers.js
@@ -33,10 +33,11 @@ module.exports = function(modelName, testData) {
             it("should return a dictionary containing domain values for each appropriate model attribute", async function() {
                 let model = sails.models[modelName];
                 let result = await sails.helpers.getDomains(model);
-                for (let property in model.attributes) {
-                    if (sails.helpers.isAssociation(model, property) ||
-                        (model.attributes[property].validations && model.attributes[property].validations.isIn)) {
-                        should.exist(result[property], `The dictionary returned by \`getDomains\` has no ${property} property`);
+                if (model.generateHtmlSelect) {
+                    for (let property in model.generateHtmlSelect) {
+                        if (model.generateHtmlSelect[property]) {
+                            should.exist(result[property], `The dictionary returned by \`getDomains\` has no ${property} property`);
+                        }
                     }
                 }
             });


### PR DESCRIPTION
Models must now say which attributes (if any) have defined domains. This means they have either an `isIn` validation or an associated model that defines the set of valid values.